### PR TITLE
Fix rules skeleton newline and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ loxvihgen all    PROJECT -u URL
 ## Examples
 See the [`examples/`](examples) folder:
 - `examples/openweather/` – One Call API response + rules + manifest
-- `examples/shelly-plug/` – Shelly Plug sample + rules + manifest
+- `examples/shelly_plug/` – Shelly Plug sample + rules + manifest
 
 ## Contributing
 PRs welcome. Please:

--- a/loxvihgen/renderer.py
+++ b/loxvihgen/renderer.py
@@ -9,7 +9,6 @@ class ViHttpXmlRenderer:
 
     @staticmethod
     def _xml_attr_escape(s: str) -> str:
-        # Minimal escape for attributes; commands provide &quot;/&lt; already
         return (s.replace("&", "&amp;")
                  .replace("\"", "&quot;")
                  .replace("<", "&lt;")

--- a/loxvihgen/rules.py
+++ b/loxvihgen/rules.py
@@ -63,4 +63,4 @@ def generate_rules_skeleton(source) -> str:
         lines.append(f'    {{"pattern":"{p}","unit":""}}{comma}')
     lines.append("  ]")
     lines.append("}")
-    return "/n".join(lines)
+    return "\n".join(lines)

--- a/tests/test_rules_skeleton.py
+++ b/tests/test_rules_skeleton.py
@@ -1,0 +1,16 @@
+from loxvihgen.rules import generate_rules_skeleton
+from loxvihgen.core import Path, ObjKey
+
+
+class DummySource:
+    def iter_numeric_leaves(self):
+        yield Path([ObjKey("$root"), ObjKey("a"), ObjKey("c")]), 1, 0
+        yield Path([ObjKey("$root"), ObjKey("a"), ObjKey("b")]), 2, 0
+
+
+def test_generate_rules_skeleton():
+    result = generate_rules_skeleton(DummySource())
+    assert result.count("\n") == 5
+    assert "/n" not in result
+    assert '{"pattern":"a.b","unit":""}' in result
+    assert '{"pattern":"a.c","unit":""}' in result


### PR DESCRIPTION
## Summary
- correct README examples path and verify example directories
- fix generate_rules_skeleton newline joining
- remove obsolete XML escape comment and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bdae334708324a949f13e99648eea