### PR TITLE
Handle missing response path in build and rules commands

### DIFF
--- a/loxvihgen/service.py
+++ b/loxvihgen/service.py
@@ -73,8 +73,9 @@ def cmd_fetch(project: str, url: Optional[str]) -> int:
 
 def cmd_rules(project: str, force: bool) -> int:
     m = load_manifest(project)
-    resp_path = Path(m.get("source", {}).get("response") or "")
-    if not resp_path.exists():
+    resp_str = m.get("source", {}).get("response")
+    resp_path = Path(resp_str) if resp_str else None
+    if not resp_path or not resp_path.is_file():
         guess = response_guess_path(project)
         if not guess:
             print(f"Error: response missing. Expected {project}.response.json or {project}.response.xml")
@@ -105,8 +106,9 @@ def cmd_rules(project: str, force: bool) -> int:
 
 def cmd_build(project: str, title: Optional[str], prefixes: List[str], sep: Optional[str], poll: Optional[int], address_url: Optional[str], output: Optional[Path]) -> int:
     m = load_manifest(project)
-    resp_path = Path(m.get("source", {}).get("response") or "")
-    if not resp_path.exists():
+    resp_str = m.get("source", {}).get("response")
+    resp_path = Path(resp_str) if resp_str else None
+    if not resp_path or not resp_path.is_file():
         guess = response_guess_path(project)
         if not guess:
             print(f"Error: response missing. Expected {project}.response.json or {project}.response.xml")

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,5 +1,6 @@
 from loxvihgen.core import ObjKey, ArrIdx, Path
 from loxvihgen.builders import TitleBuilder, JSONCheckStringBuilder, XMLCheckStringBuilder
+from loxvihgen.service import cmd_build
 
 widths = {"b": 2}
 
@@ -17,3 +18,12 @@ def test_xml_check_string():
     p = Path([ObjKey("root"), ArrIdx("item", 2), ObjKey("value")])
     chk = XMLCheckStringBuilder().build(p)
     assert '\\i&lt;root&gt;\\i' in chk and chk.endswith('\\v')
+
+
+def test_cmd_build_missing_response(tmp_path, monkeypatch, capsys):
+    project = "proj"
+    monkeypatch.chdir(tmp_path)
+    exit_code = cmd_build(project, title=None, prefixes=[], sep=None, poll=None, address_url=None, output=None)
+    captured = capsys.readouterr()
+    assert exit_code == 6
+    assert "response missing" in captured.out


### PR DESCRIPTION
## Summary
- Avoid treating empty response paths as files in `cmd_rules` and `cmd_build`
- Provide clearer error when no response file is available
- Add regression test for missing response file handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf88ccda883248a7283d04517f09c