### PR TITLE
Document command prefixes and add multi-prefix test

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,31 @@ loxvihgen all    PROJECT -u URL
    ```
 3. Build XML:
    ```bash
-   loxvihgen build weather --name-separator '.' --prefix plug1 --title 'Shelly'
+   loxvihgen build shelly_plug --name-separator '.' --prefix plug-1 --title 'Shelly Plug'
    ```
+
+### Prefixes
+
+`loxvihgen` can generate multiple sets of commands from the same response by
+prefixing their titles. This is handy when you have several identical devices
+and want their commands to remain distinct in Loxone.
+
+To build for more than one device at once, repeat `--prefix`:
+
+```bash
+loxvihgen build shelly_plug --prefix plug-1 --prefix plug-2
+```
+
+The above creates `VI_shelly_plug--plug-1.xml` and `VI_shelly_plug--plug-2.xml`, each
+containing commands such as `plug-1 …` and `plug-2 …`.
+
+Instead of passing them on the command line, prefixes may also be stored in the
+project manifest (`PROJECT.vih.json`) under the `prefixes` key. Subsequent
+`loxvihgen build PROJECT` invocations will then use those values automatically.
 
 ### Rules format (`project.rules.json`)
 ```json
-{ 
+{
   "overrides": [
     { "pattern": "temp", "unit": "°C" },
     { "pattern": "temp.min", "unit": "°C" },

--- a/loxvihgen/cli.py
+++ b/loxvihgen/cli.py
@@ -22,7 +22,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     pb = sub.add_parser("build", help="Build VI XML from project's response (+rules)")
     pb.add_argument("project")
     pb.add_argument("--title")
-    pb.add_argument("--prefix", action="append", default=[], help="Prefix for command titles (repeatable)")
+    pb.add_argument("--prefix", action="append", default=[], help="Prefix for command titles; repeat to build multiple prefixed outputs")
     pb.add_argument("--name-separator", dest="sep", default=None, help="Separator between path elements in command titles")
     pb.add_argument("--polling-time", dest="poll", type=int, default=None, help="Polling interval in seconds")
     pb.add_argument("--address-url", default=None, help="Service URL stored in XML")

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -27,3 +27,16 @@ def test_cmd_build_missing_response(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert exit_code == 6
     assert "response missing" in captured.out
+
+
+def test_cmd_build_multiple_prefixes(tmp_path, monkeypatch):
+    project = "proj"
+    resp = tmp_path / f"{project}.response.json"
+    resp.write_text('{"a": 1}')
+    monkeypatch.chdir(tmp_path)
+    exit_code = cmd_build(project, title=None, prefixes=["p1", "p2"], sep=".", poll=None, address_url=None, output=None)
+    assert exit_code == 0
+    xml1 = (tmp_path / "VI_proj--p1.xml").read_text()
+    xml2 = (tmp_path / "VI_proj--p2.xml").read_text()
+    assert 'VirtualInHttpCmd Title="p1.a"' in xml1
+    assert 'VirtualInHttpCmd Title="p2.a"' in xml2


### PR DESCRIPTION
## Summary
- Document how and why to use `--prefix` for generating multiple prefixed outputs, illustrated with Shelly Plug examples.
- Clarify CLI help regarding repeatable `--prefix` option.
- Test multi-prefix builds create separate XML files.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d14ec1ae08324bc38d03688718e93